### PR TITLE
Use JSON-reporter, then send to stylish

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,6 +1,7 @@
 var path = require('path');
 var fs = require('fs');
 var exec = require('sync-exec');
+var jshintStylish = require(require('jshint-stylish'));
 var JSHINTRC = '.jshintrc';
 var NODE_MODULES = __dirname + '/../node_modules';
 var USAGE = [
@@ -18,10 +19,10 @@ function isProjectRoot () {
 }
 
 module.exports = function (args) {
-    var cmd, result;
+    var cmd, result, failed;
     var currentDir = process.cwd();
     var jshintRc = osSep(currentDir + '/' + JSHINTRC);
-    var stylishReporter = '--reporter ' + osSep(NODE_MODULES + '/jshint-stylish/stylish.js');
+    var jsonReporter = '--reporter ' + osSep(NODE_MODULES + '/jshint-json/json.js');
 
     if (!fs.existsSync(jshintRc) && isProjectRoot()) {
         console.log('No .jshintrc found. Creating...');
@@ -33,12 +34,15 @@ module.exports = function (args) {
         process.exit(1);
     }
 
-    cmd = osSep(NODE_MODULES + '/.bin/jshint ') + stylishReporter + ' ' + args.join(' ');
+    cmd = osSep(NODE_MODULES + '/.bin/jshint ') + jsonReporter + ' ' + args.join(' ');
     result = exec(cmd);
-    if (result.status !== 0) {
+    failed = !!result.status;
+    if (failed && result.stderr) {
         console.log('jshint error!');
         console.log('jshint command used: ' + cmd);
-        if (result.stdout) { console.log(result.stdout); }
         if (result.stderr) { console.log(result.stderr); }
+    } else if (failed !== 0 && result.stdout) {
+        var report = JSON.parse(result.stdout);
+        jshintStylish.reporter(report.result, report.data);
     }
 };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,11 +1,11 @@
 {
   "name": "finn-js-code-style",
-  "version": "3.1.0",
+  "version": "4.0.1",
   "dependencies": {
     "jshint": {
       "version": "2.5.10",
-      "from": "jshint@",
-      "resolved": "http://npm.finntech.no/internal/jshint/-/jshint-2.5.10.tgz",
+      "from": "jshint@2.5.10",
+      "resolved": "http://registry.npmjs.org/jshint/-/jshint-2.5.10.tgz",
       "dependencies": {
         "cli": {
           "version": "0.6.5",
@@ -148,9 +148,14 @@
         }
       }
     },
+    "jshint-json": {
+      "version": "1.0.0",
+      "from": "jshint-json@^1.0.0",
+      "resolved": "http://registry.npmjs.org/jshint-json/-/jshint-json-1.0.0.tgz"
+    },
     "jshint-stylish": {
       "version": "1.0.0",
-      "from": "jshint-stylish@",
+      "from": "jshint-stylish@1.0.0",
       "resolved": "http://registry.npmjs.org/jshint-stylish/-/jshint-stylish-1.0.0.tgz",
       "dependencies": {
         "chalk": {
@@ -175,7 +180,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "http://npm.finntech.no/internal/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -187,7 +192,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "http://npm.finntech.no/internal/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -232,7 +237,7 @@
     },
     "sync-exec": {
       "version": "0.4.0",
-      "from": "sync-exec@",
+      "from": "sync-exec@0.4.0",
       "resolved": "http://registry.npmjs.org/sync-exec/-/sync-exec-0.4.0.tgz"
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "jshint": "2.5.10",
+    "jshint-json": "^1.0.0",
     "jshint-stylish": "1.0.0",
     "sync-exec": "0.4.0"
   }


### PR DESCRIPTION
jshint only allows one reporter, and we want to send the results to a server for graphs and other magic. Another benefit is that we don't loose the cool colors from jshint-stylish (because of sync-exec trickeries).
