### PR TITLE
Added --fail to exit with code 1 when generating errors

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -2,42 +2,82 @@ var path = require('path');
 var fs = require('fs');
 var exec = require('shelljs').exec;
 var jshintStylish = require(require('jshint-stylish'));
+
 var JSHINTRC = '.jshintrc';
 var NODE_MODULES = __dirname + '/../node_modules';
 var USAGE = [
     'Usage: finn-js-code-style <file | dir>...',
-    'Use the .jshintrc file for jshint config (should \"extend\": \"./node_modules/finn-js-code-style/.jshintrc\")',
-    'Use the .jshintignore to exclude files or folders'
+    '',
+    'Use the .jshintrc file for jshint config (should "extends": "./node_modules/finn-js-code-style/.jshintrc")',
+    'Use the .jshintignore to exclude files or folders',
+    '',
+    'Options:',
+    '\t--fail : exits with code 1 when errors are generated',
+    '\t--help : usage info'
 ].join('\n');
+
+var jshintRcPath = path.join(process.cwd(), JSHINTRC);
 
 function isProjectRoot () {
     return fs.existsSync( path.join(process.cwd(), 'package.json') );
 }
 
-module.exports = function (args) {
-    var cmd, result, report;
-    var currentDir = process.cwd();
-    var jshintRc = path.join(currentDir, JSHINTRC);
-    var jsonReporter = '--reporter ' + path.join(NODE_MODULES, 'jshint-json', 'json.js');
+function isRuntimeError(execResult) {
+    return execResult.code === 1 && execResult.output;
+}
 
-    if (!fs.existsSync(jshintRc) && isProjectRoot()) {
+function isStyleError(execResult) {
+    return execResult.code === 2  && execResult.output;
+}
+
+function isError(execResult) {
+    return execResult.code !== 0;
+}
+
+function excludeOpts(args) {
+    return args.filter(function(arg) {
+        return arg.indexOf('--') === -1;
+    });
+}
+
+function validateLocalJsHintRc() {
+    if (!fs.existsSync(jshintRcPath) && isProjectRoot()) {
         console.log('No .jshintrc found. Creating...');
-        fs.writeFileSync(jshintRc, '{\n    \"extends\": \"./node_modules/finn-js-code-style/.jshintrc\"\n}\n');
+        fs.writeFileSync(jshintRcPath, '{\n    \"extends\": \"./node_modules/finn-js-code-style/.jshintrc\"\n}\n');
     }
+}
+
+function displayResult(result, cmd) {
+    var report;
+
+    if (isRuntimeError(result)) {
+        console.error('jshint command failed, runned with: ' + cmd);
+        console.error(result.output);
+    } else if (isStyleError(result)) {
+        report = JSON.parse(result.output);
+        jshintStylish.reporter(report.result, report.data);
+    }
+}
+
+module.exports = function cli(args) {
+    var cmd, result;
+    var jsonReporter = '--reporter ' + path.join(NODE_MODULES, 'jshint-json', 'json.js');
+    var shouldFail = args.indexOf('--fail') > -1;
+    var filesToHint = excludeOpts(args).join(' ');
+
+    validateLocalJsHintRc();
 
     if (args.length === 0 || args[0] === '--help') {
         console.log(USAGE);
         process.exit(1);
     }
 
-    cmd = path.join(NODE_MODULES, '.bin', 'jshint') +  ' ' + jsonReporter + ' ' + args.join(' ');
+    cmd = path.join(NODE_MODULES, '.bin', 'jshint') +  ' ' + jsonReporter + ' ' + filesToHint;
     result = exec(cmd, {silent: true});
 
-    if (result.code === 1 && result.output) {
-        console.log('jshint command used: ' + cmd);
-        console.log(result.output);
-    } else if (result.code === 2 && result.output) {
-        report = JSON.parse(result.output);
-        jshintStylish.reporter(report.result, report.data);
+    displayResult(result, cmd);
+
+    if (isError(result) && shouldFail) {
+        process.exit(1);
     }
 };

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -1,0 +1,26 @@
+var Lab = require('lab');
+var lab = exports.lab = Lab.script();
+var assert = require('assert');
+
+var path = require('path');
+var exec = require('child_process').exec;
+
+var binPath = path.resolve(process.cwd(), 'bin', 'finn-js-code-style');
+
+lab.test('CLI exits with code 1 when generating errors and runned with --fail', function (done) {
+    var args = [binPath, __dirname + '/fixtures/invalid_jshint.js', '--fail'];
+
+    exec(args.join(' '), function onExecResult(err) {
+        assert.equal(err.code, 1);
+        done();
+    });
+});
+
+lab.test('CLI exits successfullt when generating errors and runned without --fail', function (done) {
+    var args = [binPath, __dirname + '/fixtures/invalid_jshint.js'];
+
+    exec(args.join(' '), function onExecResult(err) {
+        assert.equal(err, null);
+        done();
+    });
+});


### PR DESCRIPTION
I want my builds to fail haaard when I've got jshint errors..

Any thoughts?