### PR TITLE
Increase maxlen to 140 chars

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -26,7 +26,7 @@
     "maxdepth"      : 4,
     "maxstatements" : 20,
     "maxcomplexity" : 10,
-    "maxlen"        : 120,
+    "maxlen"        : 140,
 
     "asi"           : false,
     "boss"          : false,


### PR DESCRIPTION
Any reason we should wrap long lines at 120 chars, when the javacode we write should be wrapped at 140?